### PR TITLE
Update Documentation for IC DNS Oracle and canister id

### DIFF
--- a/docs/account-recovery/deployed-contracts.md
+++ b/docs/account-recovery/deployed-contracts.md
@@ -1,8 +1,8 @@
 ---
 title: Deployed Contracts and IC DNS Oracle | Account Recovery
 sidebar_label: Deployed Contracts and IC DNS Oracle
-description: Reference list of deployed smart contract addresses for account recovery system across Base, Base Sepolia, Sepolia, and ZKSync Era networks
-keywords: [smart contracts, contract addresses, Base, Sepolia, ZKSync Era, account recovery, blockchain deployments, DKIM registry, verifier, recovery modules]
+description: Reference list of deployed smart contract addresses for account recovery system across Base, Base Sepolia, Sepolia, and ZKSync Era networks. Also, the ICP Canister ID of the IC DNS Oracle is provided.
+keywords: [smart contracts, contract addresses, Base, Sepolia, ZKSync Era, account recovery, blockchain deployments, DKIM registry, verifier, recovery modules, IC DNS Oracle]
 ---
 
 # Deployed Contracts

--- a/docs/account-recovery/deployed-contracts.md
+++ b/docs/account-recovery/deployed-contracts.md
@@ -1,6 +1,6 @@
 ---
-title: Deployed Contracts | Account Recovery
-sidebar_label: Deployed Contracts
+title: Deployed Contracts and IC DNS Oracle | Account Recovery
+sidebar_label: Deployed Contracts and IC DNS Oracle
 description: Reference list of deployed smart contract addresses for account recovery system across Base, Base Sepolia, Sepolia, and ZKSync Era networks
 keywords: [smart contracts, contract addresses, Base, Sepolia, ZKSync Era, account recovery, blockchain deployments, DKIM registry, verifier, recovery modules]
 ---

--- a/docs/account-recovery/deployed-contracts.md
+++ b/docs/account-recovery/deployed-contracts.md
@@ -72,4 +72,10 @@ import TabItem from '@theme/TabItem';
   </TabItem>
 </Tabs>
 
+## ICP DNS Oracle
+
+| Component | Canister ID |
+| --------- | -- |
+| IC DNS Oracle | fxmww-qiaaa-aaaaj-azu7a-cai |
+
 You can additionally see our Account Recovery relayer's address at [0x9401296121FC9B78F84fc856B1F8dC88f4415B2e](https://base-sepolia.blockscout.com/address/0x9401296121FC9B78F84fc856B1F8dC88f4415B2e).

--- a/docs/email-tx-builder/architecture/generic-relayer.md
+++ b/docs/email-tx-builder/architecture/generic-relayer.md
@@ -9,8 +9,9 @@ keywords: [generic relayer, email transactions, blockchain integration, zero-kno
 
 The **Generic Relayer** allows developers to integrate email-driven actions into their blockchain applications seamlessly. By interacting with a specific API endpoint, you can trigger the execution of commands defined in a smart contract via email. The relayer handles the email verification process, zero-knowledge proof generation, and the execution of the command on the blockchain, simplifying development and enhancing security.
 
-This document provides an in-depth explanation of the architecture, including detailed technical aspects of an end-to-end implementation deployed on the Sepolia testnet.
+**ICP Canister ID**: `fxmww-qiaaa-aaaaj-azu7a-cai`
 
+This ICP Canister ID is deployed as the IC DNS Oracle on the Internet Computer. This canister generates a signature for a pair of a domain and a hash of a DKIM public key registered on the distributed name service (DNS). The signature can be verified on Ethereum, allowing smart contracts on Ethereum to verify that the given domain and public key hash are registered on the DNS. For example, this is used in ZK Email to update a DKIM registry contract, which stores the authorized public key hashes accessed during email proof verification.
 
 ## Architecture Overview
 


### PR DESCRIPTION
This update adds information about the IC DNS Oracle canister to the following documents:

1. deployed-contracts.md: Added the ICP Canister ID in a new section.
2. generic-relayer.md: Added details about the role and relevance of the IC DNS Oracle.