### PR TITLE
fix: remove /README.md suffix from documentation links

### DIFF
--- a/sidebars.ts
+++ b/sidebars.ts
@@ -45,7 +45,7 @@ const sidebars: SidebarsConfig = {
       type: 'html',
       value: '<span class="sidebar-heading">Blueprint SDK</span>',
     },
-    'zk-email-sdk/README',
+    'zk-email-sdk',
     'zk-email-sdk/setup',
     {
       type: 'category',
@@ -83,7 +83,7 @@ const sidebars: SidebarsConfig = {
       type: 'html',
       value: '<span class="sidebar-heading">ZK Email Verifier</span>',
     },
-    'zk-email-verifier/README',
+    'zk-email-verifier',
     'zk-email-verifier/setup',
     'zk-email-verifier/usage-guide',
     {


### PR DESCRIPTION
Fixed broken links in the getting started documentation by updating sidebar references:

- `zk-email-sdk/README` → `zk-email-sdk`
- `zk-email-verifier/README` → `zk-email-verifier`

This resolves 404 errors when users click on SDK and verifier links from the getting started page.

Closes #27

Generated with [Claude Code](https://claude.ai/code)