### PR TITLE
Add Redacted documentation section

### DIFF
--- a/docs/redacted/README.md
+++ b/docs/redacted/README.md
@@ -1,0 +1,44 @@
+---
+title: Overview | Redacted
+sidebar_label: Overview
+description: Redacted is a zero-knowledge email verification tool that lets users prove an email is authentic while selectively hiding sensitive content using ZK proofs.
+keywords: [redacted, zk-email, email masking, zero-knowledge proofs, DKIM verification, email privacy, selective disclosure, Noir circuits]
+---
+
+import DocCardList from '@theme/DocCardList';
+
+# Overview
+
+Redacted is a zero-knowledge email verification tool. Users upload an email, selectively mask sensitive fields, and generate a cryptographic proof that the unmasked parts are authentic. Anyone can verify the proof without seeing the original email.
+
+**Live app:** [redacted.zk.email](https://redacted.zk.email)
+
+## How it works
+
+1. User uploads a `.eml` file in the browser
+2. The app parses the email and verifies the DKIM signature
+3. User selects which fields to reveal and which to mask
+4. A ZK proof is generated entirely client-side (Noir + UltraHonk)
+5. The proof is uploaded — the original email never leaves the device
+6. Anyone with the link can verify the proof and see only the revealed content
+
+## Key properties
+
+- **Client-side proving** — the email never leaves the browser
+- **No email storage** — only the proof and masked output are persisted
+- **Cryptographic masking** — masked content is mathematically removed, not just hidden
+- **DKIM-based** — leverages existing [email authentication infrastructure](/architecture/dkim-verification)
+
+## How Redacted relates to the ZK Email ecosystem
+
+Redacted is a standalone application built on top of core ZK Email libraries:
+
+- **[`@zk-email/helpers`](/zk-email-verifier/packages/zk-email-helpers)** — used for DKIM signature verification and generating circuit inputs from raw emails
+- **[`@zk-email/zkemail-nr`](https://github.com/zkemail/zkemail.nr)** — the Noir library that provides RSA/DKIM verification, body hash extraction, and masking primitives inside the circuit
+- Uses the same [DKIM verification](/architecture/dkim-verification) and [ZK proof](/architecture/zk-proofs) concepts as the rest of the ecosystem
+
+Unlike the [Blueprint SDK](/zk-email-sdk/README), which uses Circom circuits compiled server-side, Redacted uses **Noir circuits** with the **UltraHonk** proving system. This enables the entire proof to be generated client-side in the browser via WASM — no remote prover needed.
+
+## Documentation
+
+<DocCardList />

--- a/docs/redacted/architecture.md
+++ b/docs/redacted/architecture.md
@@ -1,0 +1,118 @@
+---
+title: Architecture | Redacted
+sidebar_label: Architecture
+description: System architecture for Redacted — component overview, data flow, and key design decisions for the ZK email masking tool.
+keywords: [redacted architecture, system design, client-side proving, GCS storage, email verification]
+---
+
+# Architecture
+
+## System Overview
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│  Browser (React 19 + Vite)                                       │
+│                                                                  │
+│  ┌──────────┐  ┌──────────────┐  ┌─────────────────────────────┐ │
+│  │ Email    │  │ Interactive  │  │ ZK Proving Layer            │ │
+│  │ Upload & │→ │ Masking UI   │→ │                             │ │
+│  │ Parsing  │  │ (per-char)   │  │  Noir circuit (WASM)        │ │
+│  └──────────┘  └──────────────┘  │  + Barretenberg UltraHonk   │ │
+│       ↑                          │  → proof + public inputs     │ │
+│  postal-mime                     └──────────────┬──────────────┘ │
+│  + @zk-email/helpers (DKIM)                     │                │
+└─────────────────────────────────────────────────┼────────────────┘
+                                                  │
+                                    Upload proof via signed URL
+                                                  │
+                                                  ▼
+                              ┌──────────────────────────────────┐
+                              │  Express Backend (Node.js)       │
+                              │                                  │
+                              │  POST /api/get-proof-upload-url  │
+                              │  GET  /api/get-data/:uuid        │
+                              │  POST /api/generate-uuid         │
+                              │                                  │
+                              │  Serves static frontend (prod)   │
+                              └──────────────┬───────────────────┘
+                                             │
+                                             ▼
+                              ┌──────────────────────────────────┐
+                              │  Google Cloud Storage             │
+                              │                                  │
+                              │  eml/{uuid}/proof.json           │
+                              │  eml/{uuid}/metadata.json        │
+                              │                                  │
+                              │  (original email NEVER stored)   │
+                              └──────────────────────────────────┘
+```
+
+## Key Design Decisions
+
+**Client-side proving.** The entire ZK proof is generated in the browser. The original email never leaves the user's device. This is the core privacy guarantee.
+
+**No email storage.** The backend only stores proof outputs (masked bytes + cryptographic proof) and mask metadata. The original `.eml` file exists only in browser memory during the session.
+
+**Cross-origin isolation.** The Express server sets `Cross-Origin-Opener-Policy: same-origin` and `Cross-Origin-Embedder-Policy: require-corp` headers. This enables `SharedArrayBuffer`, which Barretenberg uses for multi-threaded proof generation via Web Workers.
+
+**Circuit variants.** Four pre-compiled Noir circuits cover the 2x2 matrix of RSA key sizes (1024/2048-bit) and email body sizes (4KB/8.4KB). The app auto-selects the smallest circuit that fits. See the [ZK Proving System](./zk-proving) page for details on each variant.
+
+## File Structure
+
+```
+src/
+├── lib.ts                    # Core: proof generation, verification, circuit loading
+├── App.tsx                   # Main app state, proof flow orchestration
+├── circuit-configs.json      # Circuit variant definitions
+├── circuit/
+│   ├── src/main.nr           # Noir circuit source
+│   ├── Nargo.toml            # Noir project config + dependencies
+│   └── target/               # Pre-compiled circuit JSON (4 variants)
+│       ├── email_mask_1024_small.json
+│       ├── email_mask_1024_mid.json
+│       ├── email_mask_2048_small.json
+│       └── email_mask_2048_mid.json
+├── utils/
+│   └── emlParser.ts          # Email parsing, DKIM, field range extraction
+├── components/
+│   ├── EmailCard.tsx          # Email display with masking UI
+│   ├── EmailField.tsx         # Individual field (From, To, etc.) with mask toggle
+│   ├── ActionBar.tsx          # Bottom bar: generate proof, undo/redo
+│   ├── UploadModal.tsx        # Drag-and-drop .eml upload
+│   ├── MaskedText.tsx         # Renders masked content as black blocks
+│   └── ...
+├── pages/
+│   ├── Home.tsx               # Landing page
+│   └── VerifyPage.tsx         # Proof verification page
+server/
+└── index.js                   # Express API + GCS integration
+```
+
+## Data Flow
+
+### Proof Generation
+
+```
+1. User drops .eml file
+2. postal-mime parses email → {from, to, subject, body, raw}
+3. @zk-email/helpers verifyDKIMSignature → DKIMResult {modulusLength, signature, ...}
+4. User masks fields → headerMask[], bodyMask[] (1=reveal, 0=hide)
+5. Select circuit by keyBits + bodyLength
+6. generateEmailVerifierInputsFromDKIMResult(dkimResult, {masks, lengths})
+7. Noir witness execution → witness
+8. UltraHonkBackend.generateProof(witness) → ProofData {publicInputs, proof}
+9. Upload proof.json + metadata.json to GCS via signed URL
+10. Redirect to /verify?id={uuid}
+```
+
+### Proof Verification
+
+```
+1. Verifier opens /verify?id={uuid}
+2. GET /api/get-data/{uuid} → {proof, headerMask, bodyMask}
+3. Extract masked header/body from publicInputs
+4. Display masked email (null bytes → black blocks)
+5. User clicks "Verify Proof"
+6. UltraHonkBackend.verifyProof(proofData) → boolean
+7. Show green (valid) or red (invalid) banner
+```

--- a/docs/redacted/architecture.md
+++ b/docs/redacted/architecture.md
@@ -9,7 +9,7 @@ keywords: [redacted architecture, system design, client-side proving, GCS storag
 
 ## System Overview
 
-```
+```text
 ┌──────────────────────────────────────────────────────────────────┐
 │  Browser (React 19 + Vite)                                       │
 │                                                                  │
@@ -59,7 +59,7 @@ keywords: [redacted architecture, system design, client-side proving, GCS storag
 
 ## File Structure
 
-```
+```text
 src/
 ├── lib.ts                    # Core: proof generation, verification, circuit loading
 ├── App.tsx                   # Main app state, proof flow orchestration
@@ -92,7 +92,7 @@ server/
 
 ### Proof Generation
 
-```
+```text
 1. User drops .eml file
 2. postal-mime parses email → {from, to, subject, body, raw}
 3. @zk-email/helpers verifyDKIMSignature → DKIMResult {modulusLength, signature, ...}
@@ -107,7 +107,7 @@ server/
 
 ### Proof Verification
 
-```
+```text
 1. Verifier opens /verify?id={uuid}
 2. GET /api/get-data/{uuid} → {proof, headerMask, bodyMask}
 3. Extract masked header/body from publicInputs

--- a/docs/redacted/backend.md
+++ b/docs/redacted/backend.md
@@ -1,0 +1,169 @@
+---
+title: Backend & Storage | Redacted
+sidebar_label: Backend & Storage
+description: Express.js backend API and Google Cloud Storage integration for Redacted — proof upload, retrieval, and storage architecture.
+keywords: [Express API, Google Cloud Storage, proof storage, signed URLs, CORS, cross-origin isolation]
+---
+
+# Backend & Storage
+
+## Overview
+
+The backend is a lightweight Express.js server that handles proof storage and retrieval via Google Cloud Storage. It intentionally does **not** handle proof generation or email processing — those happen entirely in the browser.
+
+**Source:** `server/index.js`
+
+## API Endpoints
+
+### `POST /api/generate-uuid`
+
+Generate a random UUID for a new proof.
+
+**Response:**
+```json
+{ "uuid": "6c4d4f5f-859f-4221-8ba4-53055ed006f3" }
+```
+
+---
+
+### `POST /api/get-proof-upload-url`
+
+Get a signed URL for the client to upload proof data directly to GCS.
+
+**Request:**
+```json
+{
+  "uuid": "6c4d4f5f-...",
+  "headerMask": [1, 1, 0, 0],
+  "bodyMask": [1, 1, 1, 0]
+}
+```
+
+**Response:**
+```json
+{
+  "uploadUrl": "https://storage.googleapis.com/bucket/eml/uuid/proof.json?X-Goog-Signature=...",
+  "publicUrl": "https://storage.googleapis.com/bucket/eml/uuid/proof.json",
+  "filename": "eml/uuid/proof.json",
+  "uuid": "6c4d4f5f-..."
+}
+```
+
+**What happens:**
+1. Generates a signed PUT URL (15-minute expiry) for `eml/{uuid}/proof.json`
+2. Stores `eml/{uuid}/metadata.json` with mask arrays + timestamp
+3. Client uploads proof directly to GCS using the signed URL (no proxy through backend)
+
+---
+
+### `GET /api/get-data/:uuid`
+
+Retrieve proof and metadata for verification.
+
+**Response:**
+```json
+{
+  "proof": {
+    "publicInputs": ["0x1a2b...", "0x3c4d..."],
+    "proof": [12, 34, 56]
+  },
+  "headerMask": [1, 1, 0, 0],
+  "bodyMask": [1, 1, 1, 0],
+  "createdAt": "2025-12-18T13:22:19.000Z"
+}
+```
+
+**Data normalization:** The endpoint normalizes proof data on retrieval:
+- `publicInputs` elements are ensured to be hex strings (converts arrays if stored incorrectly)
+- `proof` elements are ensured to be numbers 0-255 (converts string representations)
+
+---
+
+### `GET /health`
+
+```json
+{ "status": "ok" }
+```
+
+## GCS Storage Structure
+
+```
+bucket/
+└── eml/
+    └── {uuid}/
+        ├── proof.json       # ProofData: {publicInputs: string[], proof: number[]}
+        └── metadata.json    # {headerMask: number[], bodyMask: number[], createdAt: string}
+```
+
+**No original email is ever stored.** The proof's public inputs contain the masked header and body — sufficient for display and verification.
+
+## GCS Configuration
+
+The server supports two credential modes:
+
+**Option 1 — JSON string** (recommended for deployment):
+```bash
+GCS_CREDENTIALS='{"type":"service_account","project_id":"...","private_key":"..."}'
+```
+
+**Option 2 — Key file path:**
+```bash
+GCS_KEY_FILE=./path/to/service-account.json
+```
+
+Required environment variables:
+```bash
+GCS_PROJECT_ID=your-project-id
+GCS_BUCKET_NAME=your-bucket-name
+```
+
+### Bucket CORS Setup
+
+The bucket needs CORS configured for client-side uploads. Use `server/setup-cors.js`:
+
+```bash
+npm run setup-cors
+```
+
+This sets:
+- Allowed methods: `PUT`, `GET`, `HEAD`
+- Allowed headers: `Content-Type`, `Content-Length`
+- Allowed origins: configured from `ALLOWED_ORIGINS` env var
+
+## Cross-Origin Isolation
+
+The server sets two critical headers on all responses:
+
+```
+Cross-Origin-Opener-Policy: same-origin
+Cross-Origin-Embedder-Policy: require-corp
+```
+
+These enable `SharedArrayBuffer` in the browser, which Barretenberg's `UltraHonkBackend` uses for multi-threaded proof generation via Web Workers. Without these headers, proving falls back to single-threaded mode.
+
+## Static File Serving
+
+In production (`NODE_ENV=production`), the server also serves the built Vite frontend:
+
+```
+GET /                → dist/index.html
+GET /generate-proof  → dist/index.html (SPA fallback)
+GET /verify          → dist/index.html (SPA fallback)
+GET /assets/*        → dist/assets/* (static files)
+```
+
+API routes (`/api/*`) are registered first and take priority.
+
+## Proof Lifecycle
+
+```
+1. Client generates proof in browser
+2. Client calls POST /api/get-proof-upload-url → gets signed URL + uuid
+3. Client uploads proof.json directly to GCS via signed PUT URL
+4. Client stores proof in localStorage as fallback
+5. Client redirects to /verify?id={uuid}
+6. Verifier's browser calls GET /api/get-data/{uuid}
+7. Verifier's browser verifies proof locally (no server computation)
+```
+
+The server is stateless — it only brokers storage. All cryptographic operations happen client-side.

--- a/docs/redacted/backend.md
+++ b/docs/redacted/backend.md
@@ -87,7 +87,7 @@ Retrieve proof and metadata for verification.
 
 ## GCS Storage Structure
 
-```
+```text
 bucket/
 └── eml/
     └── {uuid}/
@@ -134,7 +134,7 @@ This sets:
 
 The server sets two critical headers on all responses:
 
-```
+```text
 Cross-Origin-Opener-Policy: same-origin
 Cross-Origin-Embedder-Policy: require-corp
 ```
@@ -145,7 +145,7 @@ These enable `SharedArrayBuffer` in the browser, which Barretenberg's `UltraHonk
 
 In production (`NODE_ENV=production`), the server also serves the built Vite frontend:
 
-```
+```text
 GET /                → dist/index.html
 GET /generate-proof  → dist/index.html (SPA fallback)
 GET /verify          → dist/index.html (SPA fallback)
@@ -156,7 +156,7 @@ API routes (`/api/*`) are registered first and take priority.
 
 ## Proof Lifecycle
 
-```
+```text
 1. Client generates proof in browser
 2. Client calls POST /api/get-proof-upload-url → gets signed URL + uuid
 3. Client uploads proof.json directly to GCS via signed PUT URL

--- a/docs/redacted/development.md
+++ b/docs/redacted/development.md
@@ -1,0 +1,205 @@
+---
+title: Development Guide | Redacted
+sidebar_label: Development Guide
+description: Local development setup, build commands, circuit compilation, deployment, and troubleshooting for Redacted.
+keywords: [development setup, Noir compilation, Barretenberg, Docker deployment, Render, environment variables]
+---
+
+# Development Guide
+
+## Prerequisites
+
+- **Node.js** 20+
+- **Yarn** (package manager)
+- **Nargo** 1.0.0-beta.5 (only for circuit compilation)
+- **Barretenberg** (`bb`) 0.84.0 (only for circuit compilation)
+
+## Quick Start
+
+```bash
+# Install dependencies
+yarn install
+
+# Start frontend dev server (http://localhost:5173)
+yarn dev
+
+# Start backend API server (http://localhost:3001)
+yarn server
+
+# Start both simultaneously
+yarn dev:full
+```
+
+## Environment Variables
+
+### Frontend (prefix with `VITE_`)
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `VITE_GCS_API_URL` | Yes | Backend API base URL. Local: `http://localhost:3001/api`. Production: `https://your-service.onrender.com/api` |
+| `VITE_POSTHOG_KEY` | No | PostHog analytics project key |
+| `VITE_POSTHOG_HOST` | No | PostHog host. Default: `https://app.posthog.com` |
+
+### Backend
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `PORT` | No | Server port. Default: `3001` (local), `10000` (Render) |
+| `NODE_ENV` | No | `development` or `production` |
+| `GCS_PROJECT_ID` | Yes | Google Cloud project ID |
+| `GCS_BUCKET_NAME` | Yes | GCS bucket name for proof storage |
+| `GCS_CREDENTIALS` | Yes* | Service account JSON string |
+| `GCS_KEY_FILE` | Yes* | Path to service account JSON file |
+| `ALLOWED_ORIGINS` | No | Comma-separated CORS origins. Default: `http://localhost:5173,http://localhost:3000` |
+
+*One of `GCS_CREDENTIALS` or `GCS_KEY_FILE` is required.
+
+### Local `.env` setup
+
+Create `server/.env`:
+
+```bash
+GCS_PROJECT_ID=your-project-id
+GCS_BUCKET_NAME=your-bucket-name
+GCS_KEY_FILE=./path-to-credentials.json
+```
+
+Create `.env` (or `.env.local`) in project root:
+
+```bash
+VITE_GCS_API_URL=http://localhost:3001/api
+```
+
+## Available Scripts
+
+| Command | Description |
+|---------|-------------|
+| `yarn dev` | Vite dev server with HMR (port 5173) |
+| `yarn server` | Express backend only (port 3001) |
+| `yarn dev:full` | Frontend + backend simultaneously |
+| `yarn build` | TypeScript check + Vite production build |
+| `yarn preview` | Serve production build locally |
+| `yarn lint` | ESLint check |
+| `yarn setup-cors` | Configure GCS bucket CORS rules |
+| `yarn compile:circuits` | Recompile Noir circuits (see below) |
+
+## Circuit Compilation
+
+Pre-compiled circuits are checked into `src/circuit/target/`. You only need to recompile if you modify `src/circuit/src/main.nr` or change circuit parameters.
+
+### Requirements
+
+```bash
+# Install Nargo (Noir compiler)
+# See: https://noir-lang.org/docs/getting_started/installation
+noirup --version 1.0.0-beta.5
+
+# Install Barretenberg
+# See: https://github.com/AztecProtocol/aztec-packages
+bbup --version 0.84.0
+```
+
+### Compiling
+
+```bash
+yarn compile:circuits
+```
+
+This script (`scripts/compile-circuits.ts`):
+
+1. Reads circuit variants from `src/circuit-configs.json`
+2. For each variant:
+   - Patches `main.nr` with the variant's `MAX_EMAIL_HEADER_LENGTH`, `MAX_EMAIL_BODY_LENGTH`, and `KEY_LIMBS`
+   - Runs `nargo compile --force --silence-warnings`
+   - Renames output to `email_mask_{variant}.json`
+   - Restores original `main.nr`
+3. All 4 compiled circuits land in `src/circuit/target/`
+
+### Circuit configuration
+
+`src/circuit-configs.json`:
+
+```json
+{
+  "circuits": [
+    { "name": "email_mask_1024_small", "maxHeaderLength": 2048, "maxBodyLength": 4096, "keyBits": 1024 },
+    { "name": "email_mask_1024_mid",   "maxHeaderLength": 2048, "maxBodyLength": 8448, "keyBits": 1024 },
+    { "name": "email_mask_2048_small", "maxHeaderLength": 2048, "maxBodyLength": 4096, "keyBits": 2048 },
+    { "name": "email_mask_2048_mid",   "maxHeaderLength": 2048, "maxBodyLength": 8448, "keyBits": 2048 }
+  ],
+  "versions": {
+    "nargo": "1.0.0-beta.5",
+    "barretenberg": "0.84.0"
+  }
+}
+```
+
+To add a new variant (e.g., larger body support), add an entry here and run `yarn compile:circuits`.
+
+## Build & Deployment
+
+### Docker
+
+```bash
+docker build \
+  --build-arg VITE_GCS_API_URL=https://your-service.onrender.com/api \
+  --build-arg VITE_POSTHOG_KEY=your-key \
+  -t redacted .
+
+docker run -p 10000:10000 \
+  -e GCS_PROJECT_ID=your-project \
+  -e GCS_BUCKET_NAME=your-bucket \
+  -e GCS_CREDENTIALS='{"type":"service_account",...}' \
+  redacted
+```
+
+The Dockerfile uses a multi-stage build:
+1. **Builder stage:** Installs all deps, creates `.env.production` from build args, runs `yarn build`
+2. **Production stage:** Installs production deps only, copies `dist/`, `server/`, and `src/circuit/`, runs `node server/index.js`
+
+### Render
+
+Deployment is configured in `render.yaml`:
+
+```yaml
+services:
+  - name: redacted-app
+    type: web
+    runtime: docker
+    plan: starter
+    envVars:
+      NODE_ENV: production
+      PORT: 10000
+      # Set these in Render dashboard:
+      # GCS_PROJECT_ID, GCS_BUCKET_NAME, GCS_CREDENTIALS
+      # VITE_GCS_API_URL, VITE_POSTHOG_KEY, VITE_POSTHOG_HOST
+```
+
+`VITE_*` variables must be set as both environment variables AND Docker build args (Render handles this via `render.yaml`).
+
+## Key Dependencies
+
+| Package | Version | Role |
+|---------|---------|------|
+| `@noir-lang/noir_js` | 1.0.0-beta.5 | Noir circuit execution in browser |
+| `@aztec/bb.js` | 0.84.0 | UltraHonk proving backend (WASM) |
+| `@zk-email/zkemail-nr` | 1.3.2-alpha.0 | DKIM verification, input generation, masking |
+| `postal-mime` | 2.6.0 | RFC 5322 email parsing |
+| `@google-cloud/storage` | 7.7.0 | GCS SDK (backend) |
+| `react` | 19.2.0 | UI framework |
+| `vite` | 7.2.2 | Build tool + dev server |
+| `vite-plugin-node-polyfills` | 0.17.0 | Node.js polyfills for browser (Buffer, etc.) |
+
+## Troubleshooting
+
+**Proof generation is slow (single-threaded):**
+Check that COOP/COEP headers are set. Open browser console and check `self.crossOriginIsolated`. If `false`, the headers aren't reaching the page.
+
+**"Unsupported DKIM key size" error:**
+The email uses a key size other than 1024 or 2048 bits. This is rare but can happen with some enterprise mail servers.
+
+**"Body too large" during upload:**
+The email body exceeds ~8.4KB. Only the raw body content counts — MIME headers and boundaries are included in the byte count.
+
+**GCS upload fails:**
+Check that bucket CORS is configured (`yarn setup-cors`) and that the service account has `storage.objects.create` and `storage.objects.get` permissions.

--- a/docs/redacted/email-parsing.md
+++ b/docs/redacted/email-parsing.md
@@ -15,7 +15,7 @@ Email parsing converts a raw `.eml` file into structured fields (From, To, Subje
 
 ## Parsing Pipeline
 
-```
+```text
 Raw .eml file (RFC 5322)
     │
     ▼
@@ -79,7 +79,7 @@ For a detailed explanation of how DKIM works — including the signing process, 
 
 Redacted uses [`verifyDKIMSignature`](/zk-email-verifier/packages/zk-email-helpers#dkim-verification) from `@zk-email/helpers` to parse the DKIM signature and extract the data needed for proof generation:
 
-```
+```text
 verifyDKIMSignature(rawEmail) returns:
     {
       modulusLength: 2048,             // RSA key size
@@ -107,7 +107,7 @@ The mask arrays (`headerMask[]`, `bodyMask[]`) are indexed by byte position in t
 
 ### UI to Circuit alignment
 
-```
+```text
 User selects text "John" in the From field
     │
     ▼

--- a/docs/redacted/email-parsing.md
+++ b/docs/redacted/email-parsing.md
@@ -1,0 +1,151 @@
+---
+title: Email Parsing & DKIM | Redacted
+sidebar_label: Email Parsing & DKIM
+description: How Redacted parses raw email files, verifies DKIM signatures, and aligns UI masking with canonicalized email content for ZK proof generation.
+keywords: [email parsing, DKIM verification, canonicalization, RFC 6376, email masking, postal-mime, field range extraction]
+---
+
+# Email Parsing & DKIM Verification
+
+## Overview
+
+Email parsing converts a raw `.eml` file into structured fields (From, To, Subject, Date, Body) and produces a `DKIMResult` used for ZK proof generation. The key challenge is ensuring the UI masking aligns with the **canonicalized** email representation that the circuit verifies.
+
+**Source:** `src/utils/emlParser.ts`
+
+## Parsing Pipeline
+
+```
+Raw .eml file (RFC 5322)
+    │
+    ▼
+PostalMime parser
+    ├── from, to, subject, date (structured)
+    ├── text body, html body
+    └── raw headers string
+    │
+    ▼
+DKIM Verification (@zk-email/helpers)
+    ├── Canonicalized headers (per DKIM spec, RFC 6376)
+    ├── Canonicalized body
+    ├── RSA public key + modulus length (1024 or 2048)
+    ├── RSA signature
+    └── DKIMResult object
+    │
+    ▼
+Field Range Extraction
+    ├── Maps each field to byte positions in raw EML
+    ├── Stores displayOffset + displayLength
+    └── Enables character-level masking in the UI
+    │
+    ▼
+ParsedEmail object → UI + proof generation
+```
+
+## ParsedEmail Interface
+
+```typescript
+interface ParsedEmail {
+  from: string;
+  to: string;
+  subject: string;
+  time: string;
+  body: string;                        // Plain text body
+  bodyText: string;                    // Fallback text extraction
+  bodyHtml?: string;                   // HTML body (if present)
+  raw: string;                         // Original .eml content
+  ranges: {
+    from?: EmailFieldRange;
+    to?: EmailFieldRange;
+    subject?: EmailFieldRange;
+    body: EmailFieldRange;
+  };
+  dkimCanonicalizedHeaders?: string;   // Headers as DKIM sees them
+  dkimCanonicalizedBody?: string;      // Body as DKIM sees them
+  dkimResult?: DKIMResult;             // Full DKIM output for proof gen
+}
+
+interface EmailFieldRange {
+  displayOffset: number;               // Start byte in raw EML
+  displayLength: number;               // Length in bytes
+}
+```
+
+## DKIM Verification
+
+DKIM (DomainKeys Identified Mail) is the cryptographic anchor that makes Redacted work. Every email from a major provider (Gmail, Outlook, etc.) is signed with the sender's domain RSA key.
+
+For a detailed explanation of how DKIM works — including the signing process, signature structure, and verification flow — see the [DKIM Verification](/architecture/dkim-verification) architecture docs.
+
+Redacted uses [`verifyDKIMSignature`](/zk-email-verifier/packages/zk-email-helpers#dkim-verification) from `@zk-email/helpers` to parse the DKIM signature and extract the data needed for proof generation:
+
+```
+verifyDKIMSignature(rawEmail) returns:
+    {
+      modulusLength: 2048,             // RSA key size
+      publicKey: BigInt,               // RSA public key modulus
+      signature: BigInt,               // RSA signature value
+      headers: Uint8Array,             // Canonicalized headers
+      body: Uint8Array,                // Canonicalized body
+      bodyHash: string,                // Base64 body hash from signature
+      ...
+    }
+```
+
+### Canonicalization and masking
+
+DKIM uses "relaxed" canonicalization (RFC 6376 Section 3.4), which normalizes whitespace, lowercases header names, and adjusts line endings. This means the bytes the circuit verifies may differ from what the raw `.eml` file contains.
+
+**This is critical for Redacted** — the UI must display the canonicalized versions so that masking positions align with what the circuit actually proves. A mask applied to the raw email would produce incorrect proofs.
+
+## Masking Alignment
+
+The mask arrays (`headerMask[]`, `bodyMask[]`) are indexed by byte position in the canonicalized content, not the raw email. Each element is:
+
+- `1` = reveal (include in proof output)
+- `0` = mask (replaced with `0x00` null byte in proof output)
+
+### UI to Circuit alignment
+
+```
+User selects text "John" in the From field
+    │
+    ▼
+UI maps selection to byte positions in canonicalized header
+    e.g., bytes [12, 13, 14, 15]
+    │
+    ▼
+headerMask[12] = 0, headerMask[13] = 0, headerMask[14] = 0, headerMask[15] = 0
+    │
+    ▼
+Mask padded to MAX_EMAIL_HEADER_LENGTH (extra positions = 1/reveal)
+    │
+    ▼
+Circuit applies mask → output header has 0x00 at positions 12-15
+```
+
+## Supported Email Formats
+
+**RSA key sizes:**
+- 1024-bit (older domains, some enterprise mail)
+- 2048-bit (Gmail, Outlook, most modern providers)
+- Other key sizes result in an error with a descriptive message
+
+**Body size limits:**
+- Small circuit: up to ~4KB body
+- Mid circuit: up to ~8.4KB body
+- Emails exceeding 8.4KB body are validated during upload and rejected with an error
+
+**MIME types:**
+- `text/plain` — directly used
+- `text/html` — extracted as-is (the circuit operates on raw body bytes, including HTML tags)
+- Multipart — all MIME boundaries and parts included in body bytes
+
+## Error Handling
+
+| Error | Cause | User message |
+|-------|-------|-------------|
+| Unsupported key size | RSA key other than 1024 or 2048-bit | "This application only supports 1024 and 2048-bit RSA keys" |
+| Body too large | Email body exceeds ~8.4KB | Validation error during upload |
+| DKIM verification failure | Corrupted email, modified after sending, or missing signature | Upload rejected |
+| No DKIM signature | Email has no DKIM-Signature header | Upload rejected |

--- a/docs/redacted/zk-proving.md
+++ b/docs/redacted/zk-proving.md
@@ -77,7 +77,7 @@ Four pre-compiled circuits cover different email sizes. Defined in `src/circuit-
 
 ### Selection logic
 
-```
+```text
 1. Detect RSA key size from DKIM result (1024 or 2048 bits)
 2. Filter circuits matching that key size
 3. Pick the smallest circuit where maxBodyLength >= actual body length
@@ -134,7 +134,7 @@ const isValid = await backend.verifyProof(proof);
 
 **Circuit detection fallback:** If circuit metadata isn't embedded in the proof, the verifier infers the circuit from `publicInputs.length`:
 
-```
+```text
 publicInputs.length = 2 + maxHeaderLength + maxBodyLength
 
 e.g., 6146 = 2 + 2048 + 4096  →  email_mask_*_small
@@ -161,7 +161,7 @@ interface ProofDataWithMetadata extends ProofData {
 
 ### Extracting masked content from publicInputs
 
-```
+```text
 publicInputs[0]     → pubkey hash (Field, hex string)
 publicInputs[1]     → email nullifier (Field, hex string)
 publicInputs[2]     → masked_header[0] (u8 as hex, e.g., "0x46" = 'F')

--- a/docs/redacted/zk-proving.md
+++ b/docs/redacted/zk-proving.md
@@ -1,0 +1,197 @@
+---
+title: ZK Proving System | Redacted
+sidebar_label: ZK Proving System
+description: Technical details of the Noir-based ZK proving system in Redacted — circuit design, proof generation, verification, and circuit variants.
+keywords: [Noir circuits, UltraHonk, Barretenberg, ZK proofs, DKIM verification, email masking circuit, WASM proving]
+---
+
+# ZK Proving System
+
+## Overview
+
+Redacted uses Noir circuits compiled to UltraHonk proofs via the Barretenberg backend. All proving happens client-side in the browser using WASM.
+
+For background on how zero-knowledge proofs work in the ZK Email ecosystem, see [ZK Proofs Architecture](/architecture/zk-proofs). Redacted's approach differs from the [Circom-based EmailVerifier](/zk-email-verifier/packages/zk-email-circuits) used by the Blueprint SDK — it uses Noir circuits with the UltraHonk proving system, which enables fully client-side proving in the browser.
+
+**Stack:**
+- **Circuit language:** [Noir](https://noir-lang.org/) v1.0.0-beta.5
+- **Proving backend:** [Barretenberg](https://github.com/AztecProtocol/barretenberg) v0.84.0 (UltraHonk)
+- **WASM execution:** `@noir-lang/noir_js` + `@noir-lang/acvm_js`
+- **Email crypto:** `@zk-email/zkemail-nr` v1.3.2-alpha.0
+
+## The Circuit
+
+**Source:** `src/circuit/src/main.nr`
+
+```noir
+fn main(
+    header: BoundedVec<u8, MAX_EMAIL_HEADER_LENGTH>,
+    body: BoundedVec<u8, MAX_EMAIL_BODY_LENGTH>,
+    pubkey: RSAPubkey<KEY_LIMBS>,
+    signature: [Field; KEY_LIMBS],
+    body_hash_index: u32,
+    dkim_header_sequence: Sequence,
+    header_mask: [bool; MAX_EMAIL_HEADER_LENGTH],
+    body_mask: [bool; MAX_EMAIL_BODY_LENGTH],
+) -> pub ([Field; 2], [u8; MAX_EMAIL_HEADER_LENGTH], [u8; MAX_EMAIL_BODY_LENGTH])
+```
+
+### What the circuit proves
+
+1. **DKIM signature is valid** — `pubkey.verify_dkim_signature(header, signature)` verifies the RSA signature over the canonicalized email header. This is the same [DKIM verification](/architecture/dkim-verification) that email servers perform, but executed inside a ZK circuit.
+
+2. **Body matches the signed hash** — Extracts the body hash from the DKIM-Signature header field, computes SHA-256 over the provided body, and asserts they match.
+
+3. **Masking is applied correctly** — `mask_text(header, header_mask)` and `mask_text(body, body_mask)` replace bytes where `mask[i] = false` with null bytes (`0x00`). This is conceptually similar to the [masking support in the Circom EmailVerifier](/zk-email-verifier/packages/zk-email-circuits#optional-inputs), but implemented natively in Noir using the `zkemail.nr` library.
+
+### Public outputs
+
+| Index | Value | Purpose |
+|-------|-------|---------|
+| `[0]` | `pubkey.hash()` | Pedersen hash of the DKIM public key — ties proof to a specific domain |
+| `[1]` | `pedersen_hash(signature)` | Email nullifier — prevents proving the same email twice |
+| `[2..2+H]` | `masked_header` | Header bytes with masked positions zeroed out |
+| `[2+H..end]` | `masked_body` | Body bytes with masked positions zeroed out |
+
+Where `H = MAX_EMAIL_HEADER_LENGTH` for the selected circuit variant.
+
+### Circuit dependencies
+
+From `src/circuit/Nargo.toml`:
+
+| Dependency | Source | Purpose |
+|------------|--------|---------|
+| `zkemail` | `@zk-email/zkemail-nr` | RSA/DKIM verification, body hash extraction, masking |
+| `sha256` | `aztec-packages` | SHA-256 variable-length hashing |
+
+## Circuit Variants
+
+Four pre-compiled circuits cover different email sizes. Defined in `src/circuit-configs.json`:
+
+| Name | RSA Key | Max Header | Max Body | Use Case |
+|------|---------|------------|----------|----------|
+| `email_mask_1024_small` | 1024-bit | 2048 bytes | 4096 bytes (~4KB) | Short emails, older domains |
+| `email_mask_1024_mid` | 1024-bit | 2048 bytes | 8448 bytes (~8.4KB) | Longer emails, older domains |
+| `email_mask_2048_small` | 2048-bit | 2048 bytes | 4096 bytes (~4KB) | Short emails, modern domains |
+| `email_mask_2048_mid` | 2048-bit | 2048 bytes | 8448 bytes (~8.4KB) | Longer emails, modern domains |
+
+### Selection logic
+
+```
+1. Detect RSA key size from DKIM result (1024 or 2048 bits)
+2. Filter circuits matching that key size
+3. Pick the smallest circuit where maxBodyLength >= actual body length
+4. If body exceeds all circuits, use the largest one (with warning)
+```
+
+Circuits are lazy-loaded and cached in a `Map<string, CompiledCircuit>`. Call `clearCircuitCache()` to free memory.
+
+## Proof Generation Pipeline
+
+```typescript
+// src/lib.ts — handleGenerateProof()
+
+// 1. DKIM verification (or reuse cached result)
+const dkimResult = existingDkimResult || await verifyDKIMSignature(email);
+
+// 2. Select circuit
+const circuitConfig = await selectCircuit(keyBits, headerMask.length, bodyMask.length);
+
+// 3. Pad masks to circuit dimensions (pad with 1 = reveal)
+const paddedHeaderMask = pad(headerMask, circuitConfig.maxHeaderLength, 1);
+const paddedBodyMask = pad(bodyMask, circuitConfig.maxBodyLength, 1);
+
+// 4. Generate circuit inputs from DKIM result
+// See @zk-email/helpers docs: /zk-email-verifier/packages/zk-email-helpers
+const inputs = await generateEmailVerifierInputsFromDKIMResult(dkimResult, {
+  headerMask: paddedHeaderMask,
+  bodyMask: paddedBodyMask,
+  maxHeadersLength: circuitConfig.maxHeaderLength,
+  maxBodyLength: circuitConfig.maxBodyLength,
+});
+
+// 5. Execute circuit → witness
+const noir = new Noir(selectedCircuit);
+const { witness } = await noir.execute(inputs);
+
+// 6. Generate proof (multi-threaded if SharedArrayBuffer available)
+const threads = self.crossOriginIsolated ? navigator.hardwareConcurrency : 1;
+const backend = new UltraHonkBackend(selectedCircuit.bytecode, { threads });
+const proof = await backend.generateProof(witness);
+```
+
+## Proof Verification
+
+```typescript
+// src/lib.ts — handleVerifyProof()
+
+// 1. Detect circuit from metadata or publicInputs length
+// 2. Load the matching circuit
+// 3. Create backend and verify
+const backend = new UltraHonkBackend(circuit.bytecode);
+const isValid = await backend.verifyProof(proof);
+```
+
+**Circuit detection fallback:** If circuit metadata isn't embedded in the proof, the verifier infers the circuit from `publicInputs.length`:
+
+```
+publicInputs.length = 2 + maxHeaderLength + maxBodyLength
+
+e.g., 6146 = 2 + 2048 + 4096  →  email_mask_*_small
+     10498 = 2 + 2048 + 8448  →  email_mask_*_mid
+```
+
+If the exact circuit can't be determined (same dimensions for 1024 vs 2048), both are tried sequentially.
+
+## Proof Data Structure
+
+```typescript
+interface ProofData {
+  publicInputs: string[];    // Hex strings, one per public output field
+  proof: Uint8Array;         // Compressed proof bytes
+}
+
+// Extended with metadata (attached by frontend, stripped before upload)
+interface ProofDataWithMetadata extends ProofData {
+  __circuitName?: string;
+  __maxHeaderLength?: number;
+  __maxBodyLength?: number;
+}
+```
+
+### Extracting masked content from publicInputs
+
+```
+publicInputs[0]     → pubkey hash (Field, hex string)
+publicInputs[1]     → email nullifier (Field, hex string)
+publicInputs[2]     → masked_header[0] (u8 as hex, e.g., "0x46" = 'F')
+publicInputs[3]     → masked_header[1]
+...
+publicInputs[2+H-1] → masked_header[H-1]
+publicInputs[2+H]   → masked_body[0]
+...
+publicInputs[2+H+B-1] → masked_body[B-1]
+```
+
+Null bytes (`0x00`) indicate masked positions. The UI renders these as solid black blocks (`U+2588`).
+
+## WASM Initialization
+
+Two WASM modules must be initialized before any circuit operations:
+
+```typescript
+import initNoirC from "@noir-lang/noirc_abi";
+import initACVM from "@noir-lang/acvm_js";
+import acvm from "@noir-lang/acvm_js/web/acvm_js_bg.wasm?url";
+import noirc from "@noir-lang/noirc_abi/web/noirc_abi_wasm_bg.wasm?url";
+
+await Promise.all([initACVM(fetch(acvm)), initNoirC(fetch(noirc))]);
+```
+
+This runs as a top-level `await` in `lib.ts` — the module blocks until both WASMs are loaded.
+
+## Performance
+
+- **Multi-threading:** Enabled when `self.crossOriginIsolated === true` (requires COOP/COEP headers). Uses `navigator.hardwareConcurrency` threads.
+- **Circuit caching:** Compiled circuits are cached in memory after first load. Circuit JSON files are ~1-5MB each.
+- **DKIM caching:** The `existingDkimResult` parameter avoids redundant DKIM verification when the result is already available from email parsing.

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -187,6 +187,25 @@ const sidebars: SidebarsConfig = {
     'jwt-tx-builder/contracts',
     {
       type: 'html',
+      value: '<span class="sidebar-heading">Redacted</span>',
+    },
+    {
+      type: 'category',
+      label: 'Redacted',
+      link: {
+        type: 'doc',
+        id: 'redacted/README',
+      },
+      items: [
+        'redacted/architecture',
+        'redacted/zk-proving',
+        'redacted/email-parsing',
+        'redacted/backend',
+        'redacted/development',
+      ],
+    },
+    {
+      type: 'html',
       value: '<span class="sidebar-heading">Additional Resources</span>',
     },
     {


### PR DESCRIPTION
## Summary
- Adds Redacted docs section to docs.zk.email with 5 pages: Overview, Architecture, ZK Proving System, Email Parsing & DKIM, Backend & Storage, and Development Guide
- Adds Redacted sidebar heading and category in `sidebars.ts`

## Test plan
- [ ] Run `npm start` and verify the Redacted section appears in the sidebar
- [ ] Verify all 6 pages render correctly
- [ ] Check that the DocCardList on the overview page lists all sub-pages

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive Redacted docs: overview, architecture, backend/API, development guide, email parsing & DKIM flow, and client-side ZK proving.
  * Documents end-to-end user flows (upload → mask → in-browser proof → upload proof → verify), required headers/CORS for browser proving, storage/layout for proof & metadata, and troubleshooting/deployment guidance.
  * Integrated Redacted section into documentation sidebar for easy discovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->