### PR TITLE
docs: update Circom optimization guidance

### DIFF
--- a/docs/zk-email-verifier/usage-guide.md
+++ b/docs/zk-email-verifier/usage-guide.md
@@ -65,7 +65,7 @@ To compile the circuit locally, you need to have Rust and Circom installed first
 circom -l node_modules MyCircuit.circom -o --r1cs --wasm --sym --c --O0
 ```
 
-Note: You can add -l to specify the directory where the directive `include` should look for the circuits indicated. For our repo use `circom -l node_modules` instead of circom. Additionally, we generally recommend using the `--O0` flag for optimization during compilation for beginners. However, if you're more experienced with Circom, feel free to use the `--O1` flag instead. It's important to avoid using the `--O2` flag as that is the default setting and it may lead to the deletion of additional constraints.
+Note: You can add -l to specify the directory where the directive `include` should look for the circuits indicated. For our repo use `circom -l node_modules` instead of circom. Additionally, we generally recommend using the `--O0` flag during compilation for beginners because it keeps the generated constraints easier to inspect. Since Circom 2.2.0, `--O1` is the default simplification level, and experienced users can use it explicitly to match the current compiler default. Reserve `--O2` for final optimization passes after reviewing the generated constraints; it was the default before Circom 2.2.0, but it is no longer the default and is not compatible with every proof system. See Circom's [constraint simplification documentation](https://docs.circom.io/circom-language/circom-insight/simplification/) for the current defaults and tradeoffs.
 
 After running this command, the circuit will be compiled into a `.r1cs` file, a `.wasm` file, and a `.sym` file. These files are used in the next steps to generate the proving and verifying keys, and to compute the witness.
 


### PR DESCRIPTION
This updates the verifier usage guide's Circom optimization note to match the current compiler behavior:

| Area | Change | Evidence |
| --- | --- | --- |
| `docs/zk-email-verifier/usage-guide.md` | Clarifies that `--O1` is the default since Circom 2.2.0, while `--O2` was the pre-2.2.0 default and should be reserved for final optimization passes. | Circom constraint simplification docs linked inline. |
| Beginner guidance | Keeps the `--O0` recommendation for easier constraint inspection while removing the incorrect claim that `--O2` is the default. | Local docs build completed. |

Validation run locally:

```text
POSTHOG_API_KEY=phc_dummy_for_local_build npx --yes yarn@1.22.22 build
[SUCCESS] Generated static files in build.

git diff --check
clean
```

Fixes #32.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated compilation guide with clearer guidance on Circom optimization flags, including recommended `--O0` setting for beginners, version-specific defaults for Circom 2.2.0+, and refined recommendations for performance optimization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zkemail/docusaurus/pull/35)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->